### PR TITLE
refactor: 모든 API 세션으로 사용자 정보 받아오는 로직으로 수정 (#108)

### DIFF
--- a/src/main/java/com/cucumber/market/api/common/handler/MemberSessionHandler.java
+++ b/src/main/java/com/cucumber/market/api/common/handler/MemberSessionHandler.java
@@ -1,0 +1,20 @@
+package com.cucumber.market.api.common.handler;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class MemberSessionHandler {
+
+    public int getMemberIdFromSession(HttpSession session){
+        int memberId = Optional.ofNullable((Map<String, Object>) session.getAttribute("userInfo"))
+                .map(userInfo -> (Map<String, Object>) userInfo.get("userInfo"))
+                .map(userInfoMap -> (Integer) userInfoMap.get("memberId"))
+                .orElseThrow();
+
+        return memberId;
+    }
+}

--- a/src/main/java/com/cucumber/market/api/controller/history/HistoryController.java
+++ b/src/main/java/com/cucumber/market/api/controller/history/HistoryController.java
@@ -1,6 +1,8 @@
 package com.cucumber.market.api.controller.history;
 
+import com.cucumber.market.api.common.handler.MemberSessionHandler;
 import com.cucumber.market.api.service.history.HistoryService;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -25,34 +27,36 @@ public class HistoryController {
 
     @Autowired
     HistoryService historyService;
+    @Autowired
+    MemberSessionHandler memberSessionHandler;
 
     @GetMapping("/sales")
-    public ResponseEntity sales(@RequestHeader(name = "memberId") int memberId, @RequestParam(required = false) Integer itemStatusId){
-
+    public ResponseEntity sales(HttpSession session, @RequestParam(required = false) Integer itemStatusId){
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",historyService.sales(memberId, itemStatusId));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);
     }
 
     @GetMapping("/purchases")
-    public ResponseEntity purchases(@RequestHeader(name = "memberId") int memberId){
-
+    public ResponseEntity purchases(HttpSession session){
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",historyService.purchases(memberId));
 
         return new ResponseEntity(body,headers,HttpStatus.OK);
     }
 
     @GetMapping("/interests")
-    public ResponseEntity interests(@RequestHeader(name = "memberId") int memberId){
-
+    public ResponseEntity interests(HttpSession session){
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",historyService.interests(memberId));
 
         return new ResponseEntity(body, headers,HttpStatus.OK);
     }
 
     @GetMapping("/itemStatus")
-    public ResponseEntity itemStatus(@RequestHeader(name = "memberId") int memberId){
-
+    public ResponseEntity itemStatus(HttpSession session){
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",historyService.itemStatus(memberId));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);

--- a/src/main/java/com/cucumber/market/api/controller/item/ItemController.java
+++ b/src/main/java/com/cucumber/market/api/controller/item/ItemController.java
@@ -1,9 +1,11 @@
 package com.cucumber.market.api.controller.item;
 
+import com.cucumber.market.api.common.handler.MemberSessionHandler;
 import com.cucumber.market.api.dto.item.ItemDto;
 import com.cucumber.market.api.service.item.ItemService;
 import com.cucumber.market.api.service.item.ItemStatus;
 import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,7 @@ import java.util.Map;
 public class ItemController {
 
     private final ItemService itemService;
+    private final MemberSessionHandler memberSessionHandler;
 
     private Map<String, Object> body = new LinkedHashMap<>() {
         {
@@ -33,7 +36,7 @@ public class ItemController {
     @PostMapping("/items")
     public ResponseEntity addItem(@RequestPart(value = "files") List<MultipartFile> files,
                                   @RequestPart(value = "addItemRequest") ItemDto.addItemDto itemDto,
-                                  @RequestHeader(name = "memberId") int memberId) {
+                                  HttpSession session) {
 
         Map<String, Object> body = new LinkedHashMap<>() {
             {
@@ -43,6 +46,7 @@ public class ItemController {
         };
 
         itemDto.setPostDate(LocalDateTime.now());
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.addItem(memberId, itemDto, files));
 
         return new ResponseEntity(body, HttpStatus.CREATED);
@@ -63,16 +67,15 @@ public class ItemController {
      * @param files - 사용자가 새로 추가한 이미지들
      * @param itemDto
      * @param itemId
-     * @param memberId
      * @return
      */
     @PutMapping("/items/{itemId}")
     public ResponseEntity modifyItem(@RequestPart(value = "files", required = false) List<MultipartFile> files,
                                      @RequestPart(value = "modifyItemRequest") ItemDto.modifyItemDto itemDto,
                                      @PathVariable(name = "itemId") int itemId,
-                                     @RequestHeader(name = "memberId") int memberId) {
-
+                                     HttpSession session) {
         itemDto.setUpdateDate(LocalDateTime.now());
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.modifyItem(memberId, itemId, itemDto, files));
 
         return new ResponseEntity(body, HttpStatus.OK);
@@ -82,8 +85,8 @@ public class ItemController {
     @PutMapping("/items/{itemId}/status")
     public ResponseEntity modifyItemStatus(@Valid @RequestBody ItemDto.modifyItemStatusDto dto,
                                            @PathVariable(name = "itemId") int itemId,
-                                           @RequestHeader(name = "memberId") int memberId) {
-
+                                           HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.modifyItemStatus(memberId, itemId, dto));
 
         return new ResponseEntity(body, HttpStatus.OK);
@@ -91,8 +94,8 @@ public class ItemController {
 
 
     @GetMapping("/items")
-    public ResponseEntity getItems(@RequestHeader(name = "memberId") int memberId) {
-
+    public ResponseEntity getItems(HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.getItems(memberId));
 
         return new ResponseEntity(body, HttpStatus.OK);
@@ -100,10 +103,10 @@ public class ItemController {
 
 
     @GetMapping("/search")
-    public ResponseEntity searchItems(@RequestHeader(name = "memberId") int memberId,
-                                      @RequestParam("name") String itemName,
-                                      @Nullable @RequestParam("status") ItemStatus itemStatus) {
-
+    public ResponseEntity searchItems(@RequestParam("name") String itemName,
+                                      @Nullable @RequestParam("status") ItemStatus itemStatus,
+                                      HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.searchItems(memberId, itemName, itemStatus));
 
         return new ResponseEntity(body, HttpStatus.OK);
@@ -112,8 +115,8 @@ public class ItemController {
 
     @DeleteMapping("/items/{itemId}")
     public ResponseEntity deleteItem(@PathVariable(name = "itemId") int itemId,
-                                     @RequestHeader(name = "memberId") int memberId) {
-
+                                     HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.deleteItem(memberId, itemId));
 
         return new ResponseEntity<>(body, HttpStatus.OK);
@@ -122,9 +125,9 @@ public class ItemController {
 
     @PutMapping("/items/{itemId}/review")
     public ResponseEntity modifyReview(@PathVariable(name = "itemId") int itemId,
-                                       @RequestHeader(name = "memberId") int memberId,
-                                       @RequestBody ItemDto.reviewDto reviewDto) {
-
+                                       @RequestBody ItemDto.reviewDto reviewDto,
+                                       HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.modifyReview(itemId, memberId, reviewDto));
 
         return new ResponseEntity(body, HttpStatus.OK);
@@ -133,8 +136,8 @@ public class ItemController {
 
     @DeleteMapping("/items/{itemId}/review")
     public ResponseEntity deleteReview(@PathVariable(name = "itemId") int itemId,
-                                       @RequestHeader(name = "memberId") int memberId) {
-
+                                       HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", itemService.deleteReview(itemId, memberId));
 
         return new ResponseEntity(body, HttpStatus.OK);

--- a/src/main/java/com/cucumber/market/api/controller/item/LikeController.java
+++ b/src/main/java/com/cucumber/market/api/controller/item/LikeController.java
@@ -1,6 +1,8 @@
 package com.cucumber.market.api.controller.item;
 
+import com.cucumber.market.api.common.handler.MemberSessionHandler;
 import com.cucumber.market.api.service.item.LikeService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,7 @@ import java.util.Map;
 public class LikeController {
 
     private final LikeService likeService;
+    private final MemberSessionHandler memberSessionHandler;
 
     private Map<String, Object> body = new LinkedHashMap<>() {
         {
@@ -26,7 +29,7 @@ public class LikeController {
 
     @PostMapping("/{itemId}/like")
     public ResponseEntity addLike(@PathVariable(name = "itemId") int itemId,
-                                  @RequestHeader(name = "memberId") int memberId) {
+                                  HttpSession session) {
 
         Map<String, Object> body = new LinkedHashMap<>() {
             {
@@ -34,7 +37,7 @@ public class LikeController {
                 put("resultMsg", "success");
             }
         };
-
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", likeService.addLike(itemId, memberId));
 
         return new ResponseEntity(body, HttpStatus.CREATED);
@@ -43,8 +46,8 @@ public class LikeController {
 
     @DeleteMapping("/{itemId}/like")
     public ResponseEntity deleteLike(@PathVariable(name = "itemId") int itemId,
-                                     @RequestHeader(name = "memberId") int memberId) {
-
+                                     HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", likeService.deleteLike(itemId, memberId));
 
         return new ResponseEntity(body, HttpStatus.OK);

--- a/src/main/java/com/cucumber/market/api/controller/item/OrderController.java
+++ b/src/main/java/com/cucumber/market/api/controller/item/OrderController.java
@@ -1,6 +1,8 @@
 package com.cucumber.market.api.controller.item;
 
+import com.cucumber.market.api.common.handler.MemberSessionHandler;
 import com.cucumber.market.api.service.item.OrderService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,7 @@ import java.util.Map;
 public class OrderController {
 
     private final OrderService orderService;
+    private final MemberSessionHandler memberSessionHandler;
 
     private Map<String, Object> body = new LinkedHashMap<>() {
         {
@@ -26,7 +29,7 @@ public class OrderController {
 
     @PostMapping("/{itemId}/order")
     public ResponseEntity addOrder(@PathVariable(name = "itemId") int itemId,
-                                   @RequestHeader(name = "memberId") int memberId) {
+                                   HttpSession session) {
 
         Map<String, Object> body = new LinkedHashMap<>() {
             {
@@ -34,7 +37,7 @@ public class OrderController {
                 put("resultMsg", "success");
             }
         };
-
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", orderService.addOrder(itemId, memberId));
 
         return new ResponseEntity(body, HttpStatus.CREATED);
@@ -43,8 +46,8 @@ public class OrderController {
 
     @GetMapping("/{itemId}/orders")
     public ResponseEntity getOrders(@PathVariable(name = "itemId") int itemId,
-                                    @RequestHeader(name = "memberId") int memberId) {
-
+                                    HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", orderService.getOrders(itemId, memberId));
 
         return new ResponseEntity(body, HttpStatus.OK);
@@ -53,8 +56,8 @@ public class OrderController {
 
     @DeleteMapping("/{itemId}/order")
     public ResponseEntity deleteOrder(@PathVariable(name = "itemId") int itemId,
-                                      @RequestHeader(name = "memberId") int memberId) {
-
+                                      HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", orderService.deleteOrder(itemId, memberId));
 
         return new ResponseEntity(body, HttpStatus.OK);

--- a/src/main/java/com/cucumber/market/api/controller/region/RegionController.java
+++ b/src/main/java/com/cucumber/market/api/controller/region/RegionController.java
@@ -1,7 +1,9 @@
 package com.cucumber.market.api.controller.region;
 
+import com.cucumber.market.api.common.handler.MemberSessionHandler;
 import com.cucumber.market.api.dto.region.RegionDto;
 import com.cucumber.market.api.service.region.RegionService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +11,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,50 +33,52 @@ public class RegionController {
 
     @Autowired
     RegionService regionService;
+    @Autowired
+    MemberSessionHandler memberSessionHandler;
 
     @GetMapping("/level1")
-    public ResponseEntity level1(@RequestHeader(name = "memberId") int memberId) {
-
+    public ResponseEntity level1(HttpSession session) {
+        memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",regionService.level1());
 
         return new ResponseEntity(body, headers, HttpStatus.OK);
     }
 
     @GetMapping("/level2")
-    public ResponseEntity level2(@RequestHeader(name = "memberId") int memberId, @ParameterObject @Valid RegionDto.level2 dto) {
-
+    public ResponseEntity level2(HttpSession session, @ParameterObject @Valid RegionDto.level2 dto) {
+        memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",regionService.level2(dto));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);
     }
 
     @GetMapping("/level3")
-    public ResponseEntity level3(@RequestHeader(name = "memberId") int memberId, @Valid RegionDto.level3 dto){
-
+    public ResponseEntity level3(HttpSession session, @Valid RegionDto.level3 dto){
+        memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",regionService.level3(dto));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);
     }
 
     @GetMapping("/level4")
-    public ResponseEntity level4(@RequestHeader(name = "memberId") int memberId, @Valid RegionDto.level4 dto){
-
+    public ResponseEntity level4(HttpSession session, @Valid RegionDto.level4 dto){
+        memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",regionService.level4(dto));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);
     }
 
     @GetMapping("/level5")
-    public ResponseEntity level5(@RequestHeader(name = "memberId") int memberId, @Valid RegionDto.level5 dto){
-
+    public ResponseEntity level5(HttpSession session, @Valid RegionDto.level5 dto){
+        memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",regionService.level5(dto));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);
     }
 
     @GetMapping("/id")
-    public ResponseEntity id(@RequestHeader(name = "memberId") int memberId, @Valid RegionDto.id dto) {
-
+    public ResponseEntity id(HttpSession session, @Valid RegionDto.id dto) {
+        memberSessionHandler.getMemberIdFromSession(session);
         body.put("data",regionService.id(dto));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);

--- a/src/main/java/com/cucumber/market/api/controller/review/ReviewController.java
+++ b/src/main/java/com/cucumber/market/api/controller/review/ReviewController.java
@@ -1,8 +1,10 @@
 package com.cucumber.market.api.controller.review;
 
+import com.cucumber.market.api.common.handler.MemberSessionHandler;
 import com.cucumber.market.api.service.review.ReviewSender;
 import com.cucumber.market.api.service.review.ReviewService;
 import com.cucumber.market.api.service.review.ReviewSort;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,7 @@ import java.util.Map;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final MemberSessionHandler memberSessionHandler;
 
     private Map<String, Object> body = new LinkedHashMap<>() {
         {
@@ -27,14 +30,13 @@ public class ReviewController {
 
     /**
      * 내가 받은 후기 전체 조회
-     * @param memberId
      * @param reviewSender
      * @return
      */
     @GetMapping
-    public ResponseEntity getReviewsOfMe(@RequestHeader(name = "memberId") int memberId,
-                                         @RequestParam(name = "sender") ReviewSender reviewSender) {
-
+    public ResponseEntity getReviewsOfMe(@RequestParam(name = "sender") ReviewSender reviewSender,
+                                         HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", reviewService.getReviewsOfMe(memberId, reviewSender));
 
         return new ResponseEntity<>(body, HttpStatus.OK);
@@ -44,15 +46,14 @@ public class ReviewController {
     /**
      * 상품 별 내가 받은 후기, 내가 보낸 후기 개별 조회
      * @param itemId
-     * @param memberId
      * @param reviewSort
      * @return
      */
     @GetMapping("/{itemId}")
     public ResponseEntity getReview(@PathVariable(name = "itemId") int itemId,
-                                    @RequestHeader(name = "memberId") int memberId,
-                                    @RequestParam(name = "reviewSort") ReviewSort reviewSort) {
-
+                                    @RequestParam(name = "reviewSort") ReviewSort reviewSort,
+                                    HttpSession session) {
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", reviewService.getReview(memberId, itemId, reviewSort));
 
         return new ResponseEntity<>(body, HttpStatus.OK);

--- a/src/main/java/com/cucumber/market/api/controller/user/UserController.java
+++ b/src/main/java/com/cucumber/market/api/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package com.cucumber.market.api.controller.user;
 
+import com.cucumber.market.api.common.handler.MemberSessionHandler;
 import com.cucumber.market.api.dto.user.UserDto;
 import com.cucumber.market.api.service.user.UserService;
 import jakarta.servlet.http.HttpSession;
@@ -13,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/user")
@@ -28,6 +28,8 @@ public class UserController {
 
     @Autowired
     UserService userService;
+    @Autowired
+    MemberSessionHandler memberSessionHandler;
 
     /**
      * 로그인 페이지 리턴
@@ -77,13 +79,7 @@ public class UserController {
      */
     @GetMapping("/profile")
     public ResponseEntity userProfile(HttpSession session){
-
-        //값이 존재하지 않으면 0(memberId가 0인 회원은 없기 때문)
-        int memberId = Optional.ofNullable((Map<String, Object>) session.getAttribute("userInfo"))
-                .map(userInfo -> (Map<String, Object>) userInfo.get("userInfo"))
-                .map(userInfoMap -> (Integer) userInfoMap.get("memberId"))
-                .orElse(0);
-
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         body.put("data", userService.userProfileGet(memberId));
 
         return new ResponseEntity(body, headers, HttpStatus.OK);
@@ -95,9 +91,10 @@ public class UserController {
      * @return
      */
     @PutMapping("/profile")
-    public ResponseEntity userProfile(@RequestHeader(name = "memberId") int memberId,
+    public ResponseEntity userProfile(HttpSession session,
                                       @RequestPart(value = "file", required = false) MultipartFile file,
                                       @RequestPart(value = "dto") @Valid UserDto.userProfilePut dto){
+        int memberId = memberSessionHandler.getMemberIdFromSession(session);
         dto.setMemberId(memberId);
         dto.setProfileImage(file);
         body.put("data",userService.userProfilePut(dto));


### PR DESCRIPTION
- HttpSession을 API 호출 시에 파라미터로 받으면 세션의 존재를 강제하기 때문에 세션에 memberId 존재하지 않을 시 memberId 에 0을 넣는 것 대신 예외를 터뜨리는 것으로 변경하였습니다. (MemberSessionHandler, RegionController 코드 참고 부탁드립니다.)
- ` int memberId = memberSessionHandler.getMemberIdFromSession(session);` 코드가 매번 반복되므로 리팩토링의 필요성이 있습니다. @SessionAttribute 사용하는 방법을 생각해봤는데요. memberId만 세션 속성으로 저장하면 코드가 훨씬 깔끔해질 것 같습니다. 그런데 찾아보니 보통 세션 저장소에 memberId 단일로 넣지 않고 멤버 객체를 넣는 것 같아서... 어떻게 생각하시는지 궁금합니다!